### PR TITLE
improve wording

### DIFF
--- a/plugins/admin/README.adoc
+++ b/plugins/admin/README.adoc
@@ -119,7 +119,7 @@ Use "kn admin autoscaling [command] --help" for more information about a comman
 #### `kn admin profiling`
 
 ----
-Enable Knative Serving components profiling and download profile data
+Enable Knative Serving components profiling and download profiling data
 
 Usage:
   kn admin profiling [flags]
@@ -129,10 +129,10 @@ Aliases:
 
 Examples:
 
-  # To enable profiling
+  # To enable Knative Serving profiling
   kn admin profiling --enable
 
-  # To download heap profile data of autoscaler
+  # To download heap profiling data of autoscaler
   kn admin profiling --target autoscaler --heap
 
   # To download 2 minutes execution trace data of networking-istio
@@ -141,12 +141,12 @@ Examples:
   # To download go routing block and memory allocations data of activator and save them to /tmp
   kn admin profiling --target activator --block --mem-allocs --save-to /tmp
 
-  # To download all available profile data for specified pod activator-5979f56548
+  # To download all available profiling data for specified pod activator-5979f56548
   kn admin profiling --target activator-5979f56548 --all
 
 
 Flags:
-      --all              Download all profiling data
+      --all              Download all available profiling data
       --block            Download go routine blocking data
       --cpu string       Download cpu profiling data, you can specify a profiling data duration with 's' for second(s), 'm' for minute(s) and 'h' for hour(s), e.g: '1m' for one minute (default "5s")
       --disable          Disable Knative Serving profiling
@@ -156,8 +156,8 @@ Flags:
   -h, --help             help for profiling
       --mem-allocs       Download memory allocations data
       --mutex            Download holders of contended mutexes data
-  -s, --save-to string   The path to save the downloaded profile data, if not speicifed, the data will be saved in current working folder
-  -t, --target string    The profiling target. It can be a Knative component name or a specific pod name, e.g: 'activator' or 'activator-586d468c99-w59cm'
+  -s, --save-to string   The path to save the downloaded profiling data, if not speicifed, the data will be saved in current working folder
+  -t, --target string    The profiling target. It can be a Knative Serving component name or a specific pod name, e.g: 'activator' or 'activator-586d468c99-w59cm'
       --thread-create    Download stack traces that led to the creation of new OS threads data
       --trace string     Download execution trace data, you can specify a trace data duration with 's' for second(s), 'm' for minute(s) and 'h' for hour(s), e.g: '1m' for one minute (default "5s")
 
@@ -225,22 +225,22 @@ Updated Knative autoscaling config enable-scale-to-zero: true
 -----
 =====
 
-#### As a Knative administrator, I want to enable Knative profiling and download profile data.
+#### As a Knative administrator, I want to enable Knative Serving profiling and download profile data.
 
-.Enable Knative profiling.
+.Enable Knative Serving profiling.
 =====
 -----
 $ kn admin profiling --enable
-Knative profiling is enabled
+Knative Serving profiling is enabled
 -----
 =====
 
-.Download 5 seconds cpu profile data of activator component and save data to /tmp folder
+.Download 5 seconds cpu profiling data of activator component and save data to /tmp folder
 =====
 -----
 $ kn admin profiling --target activator --cpu 5s --save-to /tmp
-Starting to download profile data for pod activator-586d468c99-w59cm...
-Saving 5 second(s) cpu profile data to /tmp/activator-586d468c99-w59cm_cpu_5s_20200725165758
+Starting to download profiling data for pod activator-586d468c99-w59cm...
+Saving 5 second(s) cpu profiling data to /tmp/activator-586d468c99-w59cm_cpu_5s_20200725165758
 Forwarding from 127.0.0.1:18008 -> 8008
 Forwarding from [::1]:18008 -> 8008
 Handling connection for 18008

--- a/plugins/admin/pkg/command/profiling/profiling.go
+++ b/plugins/admin/pkg/command/profiling/profiling.go
@@ -33,10 +33,10 @@ import (
 
 const (
 	profilingExample = `
-  # To enable profiling
+  # To enable Knative Serving profiling
   kn admin profiling --enable
 
-  # To download heap profile data of autoscaler
+  # To download heap profiling data of autoscaler
   kn admin profiling --target autoscaler --heap
 
   # To download 2 minutes execution trace data of networking-istio
@@ -45,15 +45,15 @@ const (
   # To download go routing block and memory allocations data of activator and save them to /tmp
   kn admin profiling --target activator --block --mem-allocs --save-to /tmp
 
-  # To download all available profile data for specified pod activator-5979f56548
+  # To download all available profiling data for specified pod activator-5979f56548
   kn admin profiling --target activator-5979f56548 --all
 `
 
-	targetFlagUsgae       = "The profiling target. It can be a Knative component name or a specific pod name, e.g: 'activator' or 'activator-586d468c99-w59cm'"
-	saveToFlagUsage       = "The path to save the downloaded profile data, if not speicifed, the data will be saved in current working folder"
-	allFlagUsage          = "Download all available profile data"
-	cpuFlagUsage          = "Download cpu profile data, you can specify a profile data duration with 's' for second(s), 'm' for minute(s) and 'h' for hour(s), e.g: '1m' for one minute"
-	heapFlagUsage         = "Download heap profile data"
+	targetFlagUsgae       = "The profiling target. It can be a Knative Serving component name or a specific pod name, e.g: 'activator' or 'activator-586d468c99-w59cm'"
+	saveToFlagUsage       = "The path to save the downloaded profiling data, if not speicifed, the data will be saved in current working folder"
+	allFlagUsage          = "Download all available profiling data"
+	cpuFlagUsage          = "Download cpu profiling data, you can specify a profiling data duration with 's' for second(s), 'm' for minute(s) and 'h' for hour(s), e.g: '1m' for one minute"
+	heapFlagUsage         = "Download heap profiling data"
 	blockFlagUsage        = "Download go routine blocking data"
 	traceFlagUsage        = "Download execution trace data, you can specify a trace data duration with 's' for second(s), 'm' for minute(s) and 'h' for hour(s), e.g: '1m' for one minute"
 	memAllocsFlagUsage    = "Download memory allocations data"
@@ -108,8 +108,8 @@ func NewProfilingCommand(p *pkg.AdminParams) *cobra.Command {
 	var profilingCmd = &cobra.Command{
 		Use:     "profiling",
 		Aliases: []string{"prof"},
-		Short:   "Profiling Knative components",
-		Long:    `Enable Knative components profiling and download profile data`,
+		Short:   "Profiling Knative Serving components",
+		Long:    `Enable Knative Serving components profiling and download profiling data`,
 		Example: profilingExample,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flags := cmd.Flags()
@@ -145,7 +145,7 @@ func NewProfilingCommand(p *pkg.AdminParams) *cobra.Command {
 
 			// --profile-type is needed
 			if !isProfileTypeSet && !isAllProfilesSet && (isTargetSet || isSaveToSet) {
-				return fmt.Errorf("requires '--all' or a specific profile type flag")
+				return fmt.Errorf("requires '--all' or a specific profiling type flag")
 			}
 			return nil
 		},
@@ -164,8 +164,8 @@ func NewProfilingCommand(p *pkg.AdminParams) *cobra.Command {
 	}
 
 	flags := profilingCmd.Flags()
-	flags.BoolVar(&pflags.enable, "enable", false, "Enable Knative profiling")
-	flags.BoolVar(&pflags.disable, "disable", false, "Disable Knative profiling")
+	flags.BoolVar(&pflags.enable, "enable", false, "Enable Knative Serving profiling")
+	flags.BoolVar(&pflags.disable, "disable", false, "Disable Knative Serving profiling")
 	flags.StringVarP(&pflags.target, "target", "t", "", targetFlagUsgae)
 	flags.StringVarP(&pflags.saveTo, "save-to", "s", "", saveToFlagUsage)
 	flags.BoolVar(&pflags.allProfiles, "all", false, allFlagUsage)
@@ -201,9 +201,9 @@ func configProfiling(c kubernetes.Interface, cmd *cobra.Command, enable bool) er
 	}
 
 	if enable {
-		cmd.Println("Knative profiling is enabled")
+		cmd.Println("Knative Serving profiling is enabled")
 	} else {
-		cmd.Println("Knative profiling is disabled")
+		cmd.Println("Knative Serving profiling is disabled")
 	}
 	return nil
 }
@@ -360,7 +360,7 @@ func downloadProfileData(p *pkg.AdminParams, cmd *cobra.Command, pflags *profili
 	if pflags.saveTo == "" {
 		pflags.saveTo, err = os.Getwd()
 		if err != nil {
-			return fmt.Errorf("fail to get current working folder to save profile data: %+v", err)
+			return fmt.Errorf("fail to get current working folder to save profiling data: %+v", err)
 		}
 	} else {
 		stat, err := os.Stat(pflags.saveTo)
@@ -412,10 +412,10 @@ func downloadProfileData(p *pkg.AdminParams, cmd *cobra.Command, pflags *profili
 		}
 	}
 
-	// iterates pods to download specified profile data
+	// iterates pods to download specified profiling data
 	for _, pod := range pods.Items {
 		err = func() error {
-			cmd.Printf("Starting to download profile data for pod %s...\n", pod.Name)
+			cmd.Printf("Starting to download profiling data for pod %s...\n", pod.Name)
 			end := make(chan struct{})
 			downloader, err := newDownloaderFunc(p, pod.Name, knNamespace, end)
 			if err != nil {
@@ -441,7 +441,7 @@ func downloadProfileData(p *pkg.AdminParams, cmd *cobra.Command, pflags *profili
 					return err
 				}
 
-				cmd.Printf("Saving %s%s profile data to %s\n", duration, k, dataFilePath)
+				cmd.Printf("Saving %s%s profiling data to %s\n", duration, k, dataFilePath)
 				err = downloader.Download(v.profileType, f, options...)
 				f.Close()
 				if err != nil {

--- a/plugins/admin/pkg/command/profiling/profiling_test.go
+++ b/plugins/admin/pkg/command/profiling/profiling_test.go
@@ -148,7 +148,7 @@ func TestNewProfilingCommand(t *testing.T) {
 		}
 		for _, args := range argsList {
 			_, err := testutil.ExecuteCommand(newProfilingCommand(), args...)
-			assert.ErrorContains(t, err, "requires '--all' or a specific profile type flag", err)
+			assert.ErrorContains(t, err, "requires '--all' or a specific profiling type flag", err)
 		}
 	})
 
@@ -251,7 +251,7 @@ func TestNewProfilingCommand(t *testing.T) {
 		cmd, client := newProfilingCommandWith(cm)
 		out, err := testutil.ExecuteCommand(cmd, "--enable")
 		assert.NilError(t, err)
-		assert.Check(t, strings.Contains(out, "Knative profiling is enabled"))
+		assert.Check(t, strings.Contains(out, "Knative Serving profiling is enabled"))
 
 		newCm, err := client.CoreV1().ConfigMaps(knNamespace).Get(obsConfigMap, metav1.GetOptions{})
 		assert.NilError(t, err)
@@ -266,7 +266,7 @@ func TestNewProfilingCommand(t *testing.T) {
 		cmd, client := newProfilingCommandWith(cm)
 		out, err := testutil.ExecuteCommand(cmd, "--disable")
 		assert.NilError(t, err)
-		assert.Check(t, strings.Contains(out, "Knative profiling is disabled"))
+		assert.Check(t, strings.Contains(out, "Knative Serving profiling is disabled"))
 
 		newCm, err := client.CoreV1().ConfigMaps(knNamespace).Get(obsConfigMap, metav1.GetOptions{})
 		assert.NilError(t, err)
@@ -397,7 +397,7 @@ func TestNewProfilingCommand(t *testing.T) {
 		assert.ErrorContains(t, err, "error downloading data", err)
 	})
 
-	t.Run("successfully downloaded profile data for a specific pod target", func(t *testing.T) {
+	t.Run("successfully downloaded profiling data for a specific pod target", func(t *testing.T) {
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
@@ -428,11 +428,11 @@ func TestNewProfilingCommand(t *testing.T) {
 
 		out, err := testutil.ExecuteCommand(cmd, "--target", podName, "--cpu", "10")
 		assert.NilError(t, err)
-		expectedMsg := fmt.Sprintf("Saving 10 second(s) cpu profile data to %s_cpu", filepath.Join(cwd, podName))
-		assert.Check(t, strings.Contains(out, expectedMsg), "expected saving cpu profile data output for"+podName)
+		expectedMsg := fmt.Sprintf("Saving 10 second(s) cpu profiling data to %s_cpu", filepath.Join(cwd, podName))
+		assert.Check(t, strings.Contains(out, expectedMsg), "expected saving cpu profiling data output for"+podName)
 	})
 
-	t.Run("successfully downloaded profile data for a knative component", func(t *testing.T) {
+	t.Run("successfully downloaded profiling data for a knative component", func(t *testing.T) {
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
@@ -467,12 +467,12 @@ func TestNewProfilingCommand(t *testing.T) {
 		out, err := testutil.ExecuteCommand(cmd, "--target", "activator", "--heap")
 		assert.NilError(t, err)
 		for _, name := range podNames {
-			expectedMsg := fmt.Sprintf("Saving heap profile data to %s_heap", filepath.Join(cwd, name))
-			assert.Check(t, strings.Contains(out, expectedMsg), "expected saving heap profile data output for "+name)
+			expectedMsg := fmt.Sprintf("Saving heap profiling data to %s_heap", filepath.Join(cwd, name))
+			assert.Check(t, strings.Contains(out, expectedMsg), "expected saving heap profiling data output for "+name)
 		}
 	})
 
-	t.Run("successfully downloaded multiple profile types data", func(t *testing.T) {
+	t.Run("successfully downloaded multiple profiling types data", func(t *testing.T) {
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
@@ -504,12 +504,12 @@ func TestNewProfilingCommand(t *testing.T) {
 		out, err := testutil.ExecuteCommand(cmd, "--target", podName, "--cpu", "8s", "--block", "--mutex")
 		assert.NilError(t, err)
 		saveFile := filepath.Join(cwd, podName)
-		assert.Check(t, strings.Contains(out, "Saving 8 second(s) cpu profile data to "+saveFile+"_cpu"), "expected saving cpu profile data output for "+podName)
-		assert.Check(t, strings.Contains(out, "Saving block profile data to "+saveFile+"_block"), "expected saving block profile data output for "+podName)
-		assert.Check(t, strings.Contains(out, "Saving mutex profile data to "+saveFile+"_mutex"), "expected saving mutex profile data output for "+podName)
+		assert.Check(t, strings.Contains(out, "Saving 8 second(s) cpu profiling data to "+saveFile+"_cpu"), "expected saving cpu profiling data output for "+podName)
+		assert.Check(t, strings.Contains(out, "Saving block profiling data to "+saveFile+"_block"), "expected saving block profiling data output for "+podName)
+		assert.Check(t, strings.Contains(out, "Saving mutex profiling data to "+saveFile+"_mutex"), "expected saving mutex profiling data output for "+podName)
 	})
 
-	t.Run("successfully downloaded all profile types data", func(t *testing.T) {
+	t.Run("successfully downloaded all profiling types data", func(t *testing.T) {
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: obsConfigMap, Namespace: knNamespace},
 			Data:       map[string]string{"profiling.enable": "true"},
@@ -542,17 +542,17 @@ func TestNewProfilingCommand(t *testing.T) {
 		assert.NilError(t, err)
 		saveFile := filepath.Join(cwd, podName)
 		expectedMsgs := map[string]string{
-			"cpu":           fmt.Sprintf("Saving %d second(s) cpu profile data to %s_cpu", defaultDuration, saveFile),
-			"heap":          fmt.Sprintf("Saving heap profile data to %s_heap", saveFile),
-			"block":         fmt.Sprintf("Saving block profile data to %s_block", saveFile),
-			"trace":         fmt.Sprintf("Saving %d second(s) trace profile data to %s_trace", defaultDuration, saveFile),
-			"mem-allocs":    fmt.Sprintf("Saving mem-allocs profile data to %s_mem-allocs", saveFile),
-			"mutex":         fmt.Sprintf("Saving mutex profile data to %s_mutex", saveFile),
-			"goroutine":     fmt.Sprintf("Saving goroutine profile data to %s_goroutine", saveFile),
-			"thread-create": fmt.Sprintf("Saving thread-create profile data to %s_thread-create", saveFile),
+			"cpu":           fmt.Sprintf("Saving %d second(s) cpu profiling data to %s_cpu", defaultDuration, saveFile),
+			"heap":          fmt.Sprintf("Saving heap profiling data to %s_heap", saveFile),
+			"block":         fmt.Sprintf("Saving block profiling data to %s_block", saveFile),
+			"trace":         fmt.Sprintf("Saving %d second(s) trace profiling data to %s_trace", defaultDuration, saveFile),
+			"mem-allocs":    fmt.Sprintf("Saving mem-allocs profiling data to %s_mem-allocs", saveFile),
+			"mutex":         fmt.Sprintf("Saving mutex profiling data to %s_mutex", saveFile),
+			"goroutine":     fmt.Sprintf("Saving goroutine profiling data to %s_goroutine", saveFile),
+			"thread-create": fmt.Sprintf("Saving thread-create profiling data to %s_thread-create", saveFile),
 		}
 		for k, v := range expectedMsgs {
-			assert.Check(t, strings.Contains(out, v), fmt.Sprintf("expected saving %s profile data output for %s", k, podName))
+			assert.Check(t, strings.Contains(out, v), fmt.Sprintf("expected saving %s profiling data output for %s", k, podName))
 		}
 	})
 }


### PR DESCRIPTION
According to Grace's comments, I improve some wordings in ```profiling``` command:
1. Changed ```profile``` to ```profiling``` in command help and output.
2. Changed ```Knative``` to ```Knative Serving``` in some places since this command is used for serving profiling.